### PR TITLE
Fixed problem parsing boolean attributes in html style attribute dicts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ This is the first major release and there are some potentially breaking changes 
 
 * Refactor of parsing code giving ~40% performance improvement
 * Added support for HTML style attribute dictionaries, e.g. `%span(foo="bar")`
+* Improved error reporting from parser to help find problems in your templates
 * Fixed attribute values not being able to include braces (https://github.com/nyaruka/django-hamlpy/issues/39)
 * Fixed attribute values which are Haml not being able to have blank lines (https://github.com/nyaruka/django-hamlpy/issues/41)
 * Fixed sequential `with` tags ended up nested (https://github.com/nyaruka/django-hamlpy/issues/23) 

--- a/hamlpy/test/test_attributes.py
+++ b/hamlpy/test/test_attributes.py
@@ -106,9 +106,16 @@ class AttributeDictParserTest(unittest.TestCase):
         assert dict(self._parse("{class: 'test\u1234'}")) == {'class': 'test\u1234'}
 
         # html style dicts
+        assert dict(self._parse("()")) == {}
+        assert dict(self._parse("(   )")) == {}
+
         assert dict(self._parse(
-            "(:class='test' :data-number = 123\n foo=\"bar\")"
-        )) == {'class': 'test', 'data-number': '123', 'foo': 'bar'}
+            "(disabled :class='test' data-number = 123\n 'foo'=\"bar\")"
+        )) == {'disabled': None, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
+
+        assert dict(self._parse(
+            "(:class='test' data-number = 123\n 'foo'=\"bar\"  \t   disabled)"
+        )) == {'disabled': None, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
 
     def test_empty_attribute_raises_error(self):
         # empty quoted string
@@ -149,7 +156,7 @@ class AttributeDictParserTest(unittest.TestCase):
             self._parse("(class='test', foo = 'bar')")
 
         # use : in HTML style dict
-        with self.assertRaisesRegexp(ParseException, "Expected \"=\". @ \"\(class:\" <-"):
+        with self.assertRaisesRegexp(ParseException, "Unexpected \":\". @ \"\(class:\" <-"):
             self._parse("(class:'test')")
 
         # use => in HTML style dict


### PR DESCRIPTION
Can't currently parse `%span(disabled id="foo")`