### PR TITLE
Tighten up allowed syntax in attribute dictionaries

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,7 +6,7 @@
 - [Doctype](#doctype)
 - [HTML Elements](#html-elements)
     - [Element Name: %](#element-name-)
-    - [Attributes: {}](#attributes-)
+    - [Attributes: {} or ()](#attributes-)
         - [Attributes without values (Boolean attributes)](#attributes-without-values-boolean-attributes)
         - ['class' and 'id' attributes](#class-and-id-attributes)
     - [Class and ID: . and #](#class-and-id--and-)
@@ -203,7 +203,7 @@ is compiled to:
 </div>
 ```
 
-These shortcuts can be combined with the attribute dictionary and they will be combined as if they were all put inside a tuple.  For example:
+These shortcuts can be combined with the attribute dictionary and they will be combined as if they were all put inside a list.  For example:
 
 ```haml
 %div#Article.article.entry{'id':'1', 'class':'visible'} Booyaka
@@ -212,19 +212,13 @@ These shortcuts can be combined with the attribute dictionary and they will be c
 is equivalent to:
 
 ```haml
-%div{'id':('Article','1'), 'class':('article','entry','visible')} Booyaka
+%div{'id':['Article','1'], 'class':['article','entry','visible']} Booyaka
 ```
 
 and would compile to:
 
 ```htmldjango
 <div id='Article_1' class='article entry visible'>Booyaka</div>
-```
-
-You can also use more pythonic array structures in the dictionary, like so:
-
-```haml
-%div{'id':['Article','1'], 'class':['article','entry','visible']} Booyaka
 ```
 
 #### Implicit div elements

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -90,30 +90,27 @@ Any string is a valid element name and an opening and closing tag will automatic
 
 ### Attributes: {} or ()
 
-Brackets represent a dictionary that is used for specifying the attributes of an element.  The dictionary is placed 
-after the tag is defined. For example:
+Haml has three different styles for attributes which are all supported. For example:
 
 ```haml
-%html{'xmlns':'http://www.w3.org/1999/xhtml', 'xml:lang':'en', 'lang':'en'}
+%html{:xmlns => 'http://www.w3.org/1999/xhtml', :lang => 'en'}
+
+%html{'xmlns': 'http://www.w3.org/1999/xhtml', 'lang': 'en'}
+
+%html(xmlns='http://www.w3.org/1999/xhtml' lang='en')
 ```
 
-is compiled to:
+are all compiled to:
 
 ```htmldjango
-<html xmlns='http://www.w3.org/1999/xhtml' xml:lang='en' lang='en'></html>
+<html xmlns='http://www.w3.org/1999/xhtml' lang='en'></html>
 ```
 
 Long attribute dictionaries can be separated into multiple lines:
 
 ```haml
-%script{'type': 'text/javascript', 'charset': 'utf-8',
-        'href': '/long/url/to/javascript/resource.js'}
-```
-
-And the more HTML-like () syntax is also supported:
-
-```haml
-%script(type='text/javascript' charset='utf-8' href='/long/url/to/javascript/resource.js')
+%script(type='text/javascript' charset='utf-8'
+        href='/long/url/to/javascript/resource.js')
 ```
 
 #### Attributes without values (Boolean attributes)
@@ -121,7 +118,7 @@ And the more HTML-like () syntax is also supported:
 Attributes without values can be specified using singe variable. For example:
 
 ```haml
-%input{'type':'checkbox', value:'Test', checked}
+%input(type='checkbox' value='Test' checked)
 ```
 
 is compiled to:
@@ -133,7 +130,7 @@ is compiled to:
 Alternatively the values can be specified using Python's ```None``` keyword (without quotes). For example:
 
 ```haml
-%input{'type':'checkbox', value:'Test', checked: None}
+%input(type='checkbox' value='Test' checked=None)
 ```
 
 is compiled to:

--- a/hamlpy/parser/attributes.py
+++ b/hamlpy/parser/attributes.py
@@ -9,6 +9,10 @@ from .generic import peek_indentation, read_line, STRING_LITERALS, WHITESPACE_CH
 
 LEADING_SPACES_REGEX = regex.compile(r'^\s+', regex.V1 | regex.MULTILINE)
 
+# non-word characters that we allow in attribute keys (in HTML style attribute dicts)
+# TODO figure out what todo about Angular 2 style attribute names with parentheses. Allow quoted attribute names?
+ATTRIBUTE_KEY_EXTRA_CHARS = {':', '-', '$', '?', '[', ']'}
+
 
 def read_attribute_value(stream):
     """
@@ -101,7 +105,7 @@ def read_ruby_attribute(stream):
     if old_style:
         stream.ptr += 1
 
-        key = read_word(stream, include_hypens=True)
+        key = read_word(stream, include_chars=('-',))
     else:
         # new style Ruby / Python style allows attribute to be quoted string
         if stream.text[stream.ptr] in STRING_LITERALS:
@@ -110,7 +114,7 @@ def read_ruby_attribute(stream):
             if not key:
                 raise ParseException("Attribute name can't be an empty string.", stream)
         else:
-            key = read_word(stream, include_hypens=True)
+            key = read_word(stream, include_chars=('-',))
 
     read_whitespace(stream)
 
@@ -144,7 +148,7 @@ def read_html_attribute(stream):
     """
     Reads an HTML style attribute, e.g. foo="bar"
     """
-    key = read_word(stream, include_hypens=True)
+    key = read_word(stream, include_chars=ATTRIBUTE_KEY_EXTRA_CHARS)
 
     # can't have attributes without whitespace separating them
     ch = stream.text[stream.ptr]

--- a/hamlpy/parser/attributes.py
+++ b/hamlpy/parser/attributes.py
@@ -135,12 +135,8 @@ def read_ruby_attribute(stream):
             value = read_attribute_value_list(stream)
         else:
             value = read_attribute_value(stream)
-
-    elif stream.text[stream.ptr] in (',', '}'):
-        value = None
-
     else:
-        stream.raise_unexpected()
+        value = None
 
     return key, value
 

--- a/hamlpy/parser/attributes.py
+++ b/hamlpy/parser/attributes.py
@@ -10,7 +10,6 @@ from .generic import peek_indentation, read_line, STRING_LITERALS, WHITESPACE_CH
 LEADING_SPACES_REGEX = regex.compile(r'^\s+', regex.V1 | regex.MULTILINE)
 
 # non-word characters that we allow in attribute keys (in HTML style attribute dicts)
-# TODO figure out what todo about Angular 2 style attribute names with parentheses. Allow quoted attribute names?
 ATTRIBUTE_KEY_EXTRA_CHARS = {':', '-', '$', '?', '[', ']'}
 
 
@@ -126,6 +125,8 @@ def read_ruby_attribute(stream):
 
         read_whitespace(stream, include_newlines=False)
 
+        stream.expect_input()
+
         if stream.text[stream.ptr] == '\n':
             stream.ptr += 1
 
@@ -161,6 +162,8 @@ def read_html_attribute(stream):
         read_symbol(stream, '=')
 
         read_whitespace(stream, include_newlines=False)
+
+        stream.expect_input()
 
         if stream.text[stream.ptr] == '\n':
             stream.ptr += 1

--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -6,19 +6,19 @@ from .attributes import read_attribute_dict
 from .generic import read_word, read_line
 
 
-# non-word characters that we allow in ids and classes
-ID_AND_CLASS_EXTRA_CHARS = ('-',)
+# non-word characters that we allow in tag names, ids and classes
+DOM_OBJECT_EXTRA_CHARS = ('-',)
 
 
 def read_tag(stream):
     """
     Reads an element tag, e.g. span, ng-repeat, cs:dropdown
     """
-    part1 = read_word(stream, ('-',))
+    part1 = read_word(stream, DOM_OBJECT_EXTRA_CHARS)
 
     if stream.ptr < stream.length and stream.text[stream.ptr] == ':':
         stream.ptr += 1
-        part2 = read_word(stream, ('-',))
+        part2 = read_word(stream, DOM_OBJECT_EXTRA_CHARS)
     else:
         part2 = None
 
@@ -42,7 +42,7 @@ def read_element(stream):
         # Element may start with a period representing an unidentified div rather than a CSS class. In this case it
         # can't have other classes or ids, e.g. .{foo:"bar"}
         next_ch = stream.text[stream.ptr + 1] if stream.ptr < stream.length - 1 else None
-        if not (next_ch.isalnum() or next_ch == '_' or next_ch in ID_AND_CLASS_EXTRA_CHARS):
+        if not (next_ch.isalnum() or next_ch == '_' or next_ch in DOM_OBJECT_EXTRA_CHARS):
             stream.ptr += 1
             empty_class = True
 
@@ -54,7 +54,7 @@ def read_element(stream):
             is_id = stream.text[stream.ptr] == '#'
             stream.ptr += 1
 
-            id_or_class = read_word(stream, ID_AND_CLASS_EXTRA_CHARS)
+            id_or_class = read_word(stream, DOM_OBJECT_EXTRA_CHARS)
             if is_id:
                 ids.append(id_or_class)
             else:

--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -6,15 +6,19 @@ from .attributes import read_attribute_dict
 from .generic import read_word, read_line
 
 
+# non-word characters that we allow in ids and classes
+ID_AND_CLASS_EXTRA_CHARS = ('-',)
+
+
 def read_tag(stream):
     """
     Reads an element tag, e.g. span, ng-repeat, cs:dropdown
     """
-    part1 = read_word(stream, include_hypens=True)
+    part1 = read_word(stream, ('-',))
 
     if stream.ptr < stream.length and stream.text[stream.ptr] == ':':
         stream.ptr += 1
-        part2 = read_word(stream, include_hypens=True)
+        part2 = read_word(stream, ('-',))
     else:
         part2 = None
 
@@ -38,7 +42,7 @@ def read_element(stream):
         # Element may start with a period representing an unidentified div rather than a CSS class. In this case it
         # can't have other classes or ids, e.g. .{foo:"bar"}
         next_ch = stream.text[stream.ptr + 1] if stream.ptr < stream.length - 1 else None
-        if not (next_ch.isalnum() or next_ch == '_' or next_ch == '-'):
+        if not (next_ch.isalnum() or next_ch == '_' or next_ch in ID_AND_CLASS_EXTRA_CHARS):
             stream.ptr += 1
             empty_class = True
 
@@ -50,7 +54,7 @@ def read_element(stream):
             is_id = stream.text[stream.ptr] == '#'
             stream.ptr += 1
 
-            id_or_class = read_word(stream, include_hypens=True)
+            id_or_class = read_word(stream, ID_AND_CLASS_EXTRA_CHARS)
             if is_id:
                 ids.append(id_or_class)
             else:

--- a/hamlpy/parser/generic.py
+++ b/hamlpy/parser/generic.py
@@ -22,6 +22,22 @@ class Stream(object):
         self.length = len(self.text)
         self.ptr = 0
 
+    def expect_input(self):
+        """
+        We expect more input, raise exception if there isn't any
+        """
+        if self.ptr >= self.length:
+            raise ParseException("Unexpected end of input.", self)
+
+    def raise_unexpected(self):
+        """
+        Raises exception that current character is unexpected
+        """
+        raise ParseException("Unexpected \"%s\"." % self.text[self.ptr], self)
+
+    def __repr__(self):  # pragma: no cover
+        return '"%s" >> "%s"' % (self.text[:self.ptr], self.text[self.ptr:])
+
 
 class TreeNode(object):
     """
@@ -153,6 +169,8 @@ def read_word(stream, include_hypens=False):
     """
     Reads a sequence of word characters
     """
+    stream.expect_input()
+
     start = stream.ptr
 
     while stream.ptr < stream.length:
@@ -160,5 +178,9 @@ def read_word(stream, include_hypens=False):
         if not (ch.isalnum() or ch == '_' or (ch == '-' and include_hypens)):
             break
         stream.ptr += 1
+
+    # if we immediately hit a non-word character, raise it as unexpected
+    if start == stream.ptr:
+        stream.raise_unexpected()
 
     return stream.text[start:stream.ptr]

--- a/hamlpy/parser/generic.py
+++ b/hamlpy/parser/generic.py
@@ -36,7 +36,8 @@ class Stream(object):
         raise ParseException("Unexpected \"%s\"." % self.text[self.ptr], self)
 
     def __repr__(self):  # pragma: no cover
-        return '"%s" >> "%s"' % (self.text[:self.ptr], self.text[self.ptr:])
+        return '"%s" >> "%s"' \
+               % (self.text[:self.ptr].replace('\n', '\\n'), self.text[self.ptr:].replace('\n', '\\n'))
 
 
 class TreeNode(object):
@@ -165,7 +166,7 @@ def read_symbol(stream, symbols):
     raise ParseException("Expected %s." % ' or '.join(['"%s"' % s for s in symbols]), stream)
 
 
-def read_word(stream, include_hypens=False):
+def read_word(stream, include_chars=()):
     """
     Reads a sequence of word characters
     """
@@ -175,7 +176,7 @@ def read_word(stream, include_hypens=False):
 
     while stream.ptr < stream.length:
         ch = stream.text[stream.ptr]
-        if not (ch.isalnum() or ch == '_' or (ch == '-' and include_hypens)):
+        if not (ch.isalnum() or ch == '_' or ch in include_chars):
             break
         stream.ptr += 1
 

--- a/hamlpy/test/templates/classIdMixtures.hamlpy
+++ b/hamlpy/test/templates/classIdMixtures.hamlpy
@@ -1,4 +1,4 @@
-%div#Article.article.entry{'id':'123', 'class':'true'}
+%div#Article.article.entry{'id':'123', class:'true'}
   Now this is interesting
-%div.article.entry#Article('id'='123' 'class'='true')
+%div.article.entry#Article(id='123' class='true')
   Now this is really interesting

--- a/hamlpy/test/templates/multiLineDict.hamlpy
+++ b/hamlpy/test/templates/multiLineDict.hamlpy
@@ -2,5 +2,5 @@
   %img{'src': '/static/imgs/ibl_logo{{id}}.gif', 
        'alt': 'IBL Logo'}
   %br
-  %img('src'='/static/imgs/ibl_logo.gif'
-       'alt'='IBL Logo{{id}}')
+  %img(src='/static/imgs/ibl_logo.gif'
+       alt = 'IBL Logo{{id}}')

--- a/hamlpy/test/test_attributes.py
+++ b/hamlpy/test/test_attributes.py
@@ -133,7 +133,7 @@ class AttributeDictParserTest(unittest.TestCase):
         # attribute names with characters found in JS frameworks
         assert dict(self._parse('([foo]="a" ?foo$="b")')) == {'[foo]': 'a', '?foo$': 'b'}
 
-    def test_empty_attribute_raises_error(self):
+    def test_empty_attribute_name_raises_error(self):
         # empty quoted string in Ruby new style
         with self.assertRaisesRegexp(ParseException, "Attribute name can't be an empty string. @ \"{'':\" <-"):
             self._parse("{'': 'test'}")
@@ -147,6 +147,14 @@ class AttributeDictParserTest(unittest.TestCase):
             self._parse("(='test')")
         with self.assertRaisesRegexp(ParseException, "Unexpected \"=\". @ \"\(foo='bar' =\" <-"):
             self._parse("(foo='bar' ='test')")
+
+    def test_empty_attribute_value_raises_error(self):
+        with self.assertRaisesRegexp(ParseException, "Unexpected \"}\". @ \"{:class=>}\" <-"):
+            self._parse("{:class=>}")
+        with self.assertRaisesRegexp(ParseException, "Unexpected \"}\". @ \"{class:}\" <-"):
+            self._parse("{class:}")
+        with self.assertRaisesRegexp(ParseException, "Unexpected \"\)\". @ \"\(class=\)\" <-"):
+            self._parse("(class=)")
 
     def test_unterminated_string_raises_error(self):
         # on attribute key
@@ -194,3 +202,11 @@ class AttributeDictParserTest(unittest.TestCase):
         # use => in HTML style dict
         with self.assertRaisesRegexp(ParseException, "Unexpected \">\". @ \"\(class=>\" <-"):
             self._parse("(class=>'test')")
+
+    def test_unexpected_eof(self):
+        with self.assertRaisesRegexp(ParseException, "Unexpected end of input. @ \"{:class=>\" <-"):
+            self._parse("{:class=>")
+        with self.assertRaisesRegexp(ParseException, "Unexpected end of input. @ \"{class:\" <-"):
+            self._parse("{class:")
+        with self.assertRaisesRegexp(ParseException, "Unexpected end of input. @ \"\(class=\" <-"):
+            self._parse("(class=")

--- a/hamlpy/test/test_attributes.py
+++ b/hamlpy/test/test_attributes.py
@@ -109,14 +109,24 @@ class AttributeDictParserTest(unittest.TestCase):
         assert dict(self._parse("{class: 'test\u1234'}")) == {'class': 'test\u1234'}
 
     def test_read_html_style_attribute_dict(self):
-        # empty dict
-        stream = Stream("{}><")
-        assert dict(read_attribute_dict(stream)) == {}
-        assert stream.text[stream.ptr:] == '><'
-
         # html style dicts
         assert dict(self._parse("()><")) == {}
         assert dict(self._parse("(   )")) == {}
+
+        # string values
+        assert dict(self._parse("(class='test') =Test")) == {'class': 'test'}
+        assert dict(self._parse("(class='test' id='something')")) == {'class': 'test', 'id': 'something'}
+
+        # integer values
+        assert dict(self._parse("(data-number=0)")) == {'data-number': '0'}
+        assert dict(self._parse("(data-number=12345)")) == {'data-number': '12345'}
+
+        # float values
+        assert dict(self._parse("(data-number=123.456)")) == {'data-number': '123.456'}
+        assert dict(self._parse("(data-number=0.001)")) == {'data-number': '0.001'}
+
+        # None value
+        assert dict(self._parse("(controls=None)")) == {'controls': None}
 
         # boolean attributes
         assert dict(self._parse(
@@ -132,6 +142,9 @@ class AttributeDictParserTest(unittest.TestCase):
 
         # attribute names with characters found in JS frameworks
         assert dict(self._parse('([foo]="a" ?foo$="b")')) == {'[foo]': 'a', '?foo$': 'b'}
+
+        # double quotes
+        assert dict(self._parse('(class="test" id="something")')) == {'class': 'test', 'id': 'something'}
 
         # list attribute values
         assert dict(self._parse(

--- a/hamlpy/test/test_attributes.py
+++ b/hamlpy/test/test_attributes.py
@@ -127,6 +127,12 @@ class AttributeDictParserTest(unittest.TestCase):
             "(class='test' data-number = 123\n foo=\"bar\"  \t   disabled)"
         )) == {'disabled': None, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
 
+        # attribute name has colon
+        assert dict(self._parse('(xml:lang="en")')) == {'xml:lang': 'en'}
+
+        # attribute names with characters found in JS frameworks
+        assert dict(self._parse('([foo]="a" ?foo$="b")')) == {'[foo]': 'a', '?foo$': 'b'}
+
     def test_empty_attribute_raises_error(self):
         # empty quoted string in Ruby new style
         with self.assertRaisesRegexp(ParseException, "Attribute name can't be an empty string. @ \"{'':\" <-"):
@@ -177,13 +183,9 @@ class AttributeDictParserTest(unittest.TestCase):
         with self.assertRaisesRegexp(ParseException, "Unexpected \",\". @ \"\(class='test',\" <-"):
             self._parse("(class='test', foo = 'bar')")
 
-        # use : for assignment in HTML style dict
-        with self.assertRaisesRegexp(ParseException, "Unexpected \":\". @ \"\(class:\" <-"):
+        # use : for assignment in HTML style dict (will treat as part of attribute name)
+        with self.assertRaisesRegexp(ParseException, "Unexpected \"'\". @ \"\(class:'\" <-"):
             self._parse("(class:'test')")
-
-        # use : attribute prefix in HTML style dict
-        with self.assertRaisesRegexp(ParseException, "Unexpected \":\". @ \"\(:\" <-"):
-            self._parse("(:class='test')")
 
         # use attribute quotes in HTML style dict
         with self.assertRaisesRegexp(ParseException, "Unexpected \"'\". @ \"\('\" <-"):

--- a/hamlpy/test/test_compiler.py
+++ b/hamlpy/test/test_compiler.py
@@ -178,6 +178,8 @@ test''', "test")
 
     def test_escaping(self):
         self._test("\\= Escaped", "= Escaped")
+        self._test("\%}", "%}")
+        self._test("  \:python", "  :python")
 
     def test_utf8(self):
         self._test("%a{'href':'', 'title':'링크(Korean)'} Some Link",

--- a/hamlpy/test/test_parser.py
+++ b/hamlpy/test/test_parser.py
@@ -90,7 +90,7 @@ class ParserTest(unittest.TestCase):
         assert stream.text[stream.ptr:] == '-repeat('
 
         stream = Stream('ng-repeat(')
-        assert read_word(stream, include_hypens=True) == 'ng-repeat'
+        assert read_word(stream, ('-',)) == 'ng-repeat'
         assert stream.text[stream.ptr:] == '('
 
         stream = Stream('これはテストです...')


### PR DESCRIPTION
Allowed:

```haml
%{:foo => "bar"}  // old style Ruby
%{"foo": "bar"}  // new style Ruby / Python
%{foo: "bar"}  // new style Ruby without quotes
%(foo="bar")  // HTML style
%(ng:foo="bar")  // HTML style with colon in attribute name

%{foo:["a", "b"]}  // Ruby style with list attribute value
%{foo:("a", "b")}  // Ruby style with tuple attribute value
%(foo=["a", "b"])  // HTML style with list attribute value
```

Disallowed:

```haml
%{foo => "bar"}  // missing colon prefix
%{:foo: "bar"}  // colon as prefix and assignment
%("foo"="bar")  // quotes with HTML style attribute *

%(foo=("a", "b"))  // HTML style with tuple attribute value
```

\* We may want to allow this at some point to support characters in attribute names like parentheses as used by Angular 2, but want to see what direction actual Haml takes to support this: https://github.com/haml/haml/issues/876

This PR also improves error reporting during attribute parsing