### PR TITLE
Node parsing should always treat native django tags as plain text

### DIFF
--- a/hamlpy/parser/nodes.py
+++ b/hamlpy/parser/nodes.py
@@ -42,10 +42,8 @@ def read_node(stream, prev, compiler):
         if stream.text[stream.ptr] == FILTER_PREFIX:
             return read_filter_node(stream, indent, compiler)
 
-        # peek ahead to differentiate between variable node starting #{.. and element node starting #\w...
-        is_variable = stream.ptr < stream.length - 1 and stream.text[stream.ptr:stream.ptr+2] == '#{'
-
-        if stream.text[stream.ptr] in ELEMENT_PREFIXES and not is_variable:
+        # peek ahead to so we don't try to parse an element from a variable node starting #{ or a Django tag ending %}
+        if stream.text[stream.ptr] in ELEMENT_PREFIXES and stream.text[stream.ptr:stream.ptr+2] not in ('#{', '%}'):
             element = read_element(stream)
             return ElementNode(element, indent, compiler)
 

--- a/hamlpy/test/test_compiler.py
+++ b/hamlpy/test/test_compiler.py
@@ -14,6 +14,9 @@ class CompilerTest(unittest.TestCase):
         # tags can have xml namespaces
         self._test("%fb:tag\n  content", "<fb:tag>\n  content\n</fb:tag>")
 
+        # tags can have dashes
+        self._test("%ng-tag\n  content", "<ng-tag>\n  content\n</ng-tag>")
+
     def test_ids_and_classes(self):
         # id on tag
         self._test('%div#someId Some text', "<div id='someId'>Some text</div>")
@@ -128,6 +131,10 @@ test''', "test")
         self._test("This should be plain text", "This should be plain text")
         self._test("This should be plain text\n    This should be indented",
                    "This should be plain text\n    This should be indented")
+
+        # native Django tags {% %} should be treated as plain text
+        self._test("text   {%\n  trans ''\n%}", "text   {%\n  trans ''\n%}")
+        self._test("text\n   {%\n  trans ''\n%}", "text\n   {%\n  trans ''\n%}")
 
     def test_plain_filter(self):
         # with indentation

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -136,6 +136,9 @@ class ElementTest(unittest.TestCase):
         element = read_element(Stream("%div Some Text"))
         assert element.inline_content == 'Some Text'
 
+        element = read_element(Stream("%div {% trans 'hello' %}"))
+        assert element.inline_content == "{% trans 'hello' %}"
+
     def test_multiline_attributes(self):
         element = read_element(Stream("""%link{'rel': 'stylesheet', 'type': 'text/css',
             'href': '/long/url/to/stylesheet/resource.css'}"""))


### PR DESCRIPTION
i.e. don't try to parse %} as an element. This addresses #45 