### PR TITLE
Attribute dictionary tweaks

### DIFF
--- a/hamlpy/compiler.py
+++ b/hamlpy/compiler.py
@@ -105,7 +105,10 @@ class Compiler:
     }
 
     def __init__(self, options=None):
-        self.options = Options(**(options or {}))
+        if isinstance(options, Options):
+            self.options = options
+        else:
+            self.options = Options(**(options or {}))
 
         tag_config = self.TAG_CONFIGS[self.options.tag_config]
         self.self_closing_tags = tag_config['self_closing']

--- a/hamlpy/compiler.py
+++ b/hamlpy/compiler.py
@@ -105,10 +105,7 @@ class Compiler:
     }
 
     def __init__(self, options=None):
-        if isinstance(options, Options):
-            self.options = options
-        else:
-            self.options = Options(**(options or {}))
+        self.options = Options(**(options or {}))
 
         tag_config = self.TAG_CONFIGS[self.options.tag_config]
         self.self_closing_tags = tag_config['self_closing']

--- a/hamlpy/parser/attributes.py
+++ b/hamlpy/parser/attributes.py
@@ -36,10 +36,8 @@ def read_attribute_value(stream, compiler):
 
         if raw_value.lower() in ATTRIBUTE_VALUE_KEYWORDS:
             value = ATTRIBUTE_VALUE_KEYWORDS[raw_value.lower()]
-        elif raw_value:
-            value = '{{ %s }}' % raw_value
         else:
-            raise ParseException("Unexpected \"%s\"." % ch, stream)
+            value = '{{ %s }}' % raw_value
 
     return value
 

--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -145,10 +145,10 @@ class Element(object):
         rendered = []
 
         for name, value in self.attributes.items():
-            if name in ('id', 'class'):
+            if name in ('id', 'class') or value in (None, False):
                 continue
 
-            if value is None:
+            if value is True:
                 rendered.append("%s" % name)  # boolean attribute
             else:
                 value = self._escape_attribute_quotes(value, attr_wrapper)

--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -146,7 +146,8 @@ class Element(object):
 
         for name, value in self.attributes.items():
             if name in ('id', 'class') or value in (None, False):
-                continue
+                # this line isn't recorded in coverage because it gets optimized away (http://bugs.python.org/issue2506)
+                continue  # pragma: no cover
 
             if value is True:  # boolean attribute
                 if options.xhtml:

--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -26,7 +26,7 @@ def read_tag(stream):
     return (part1 + ':' + part2) if part2 else part1
 
 
-def read_element(stream, options):
+def read_element(stream, compiler):
     """
     Reads an element, e.g. %span, #banner{style:"width: 100px"}, .ng-hide(foo=1)
     """
@@ -63,7 +63,7 @@ def read_element(stream, options):
 
     attributes = OrderedDict()
     while stream.ptr < stream.length and stream.text[stream.ptr] in ('{', '('):
-        attributes.update(read_attribute_dict(stream, options))
+        attributes.update(read_attribute_dict(stream, compiler))
 
     if stream.ptr < stream.length and stream.text[stream.ptr] == '>':
         stream.ptr += 1

--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -2,6 +2,7 @@ from __future__ import print_function, unicode_literals
 
 import six
 
+from collections import OrderedDict
 from .attributes import read_attribute_dict
 from .core import read_word, read_line
 
@@ -60,10 +61,9 @@ def read_element(stream, options):
             else:
                 classes.append(id_or_class)
 
-    if stream.ptr < stream.length and stream.text[stream.ptr] in ('{', '('):
-        attributes = read_attribute_dict(stream, options)
-    else:
-        attributes = {}
+    attributes = OrderedDict()
+    while stream.ptr < stream.length and stream.text[stream.ptr] in ('{', '('):
+        attributes.update(read_attribute_dict(stream, options))
 
     if stream.ptr < stream.length and stream.text[stream.ptr] == '>':
         stream.ptr += 1

--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -138,9 +138,9 @@ class Element(object):
 
         self.classes = class_from_attrs + classes
 
-    def render_attributes(self, attr_wrapper):
+    def render_attributes(self, options):
         def attr_wrap(val):
-            return '%s%s%s' % (attr_wrapper, val, attr_wrapper)
+            return '%s%s%s' % (options.attr_wrapper, val, options.attr_wrapper)
 
         rendered = []
 
@@ -148,10 +148,13 @@ class Element(object):
             if name in ('id', 'class') or value in (None, False):
                 continue
 
-            if value is True:
-                rendered.append("%s" % name)  # boolean attribute
+            if value is True:  # boolean attribute
+                if options.xhtml:
+                    rendered.append("%s=%s" % (name, attr_wrap(name)))
+                else:
+                    rendered.append(name)
             else:
-                value = self._escape_attribute_quotes(value, attr_wrapper)
+                value = self._escape_attribute_quotes(value, options.attr_wrapper)
                 rendered.append("%s=%s" % (name, attr_wrap(value)))
 
         if len(self.classes) > 0:

--- a/hamlpy/parser/nodes.py
+++ b/hamlpy/parser/nodes.py
@@ -267,7 +267,7 @@ class ElementNode(Node):
         """
         start = ["%s<%s" % (self.indent, element.tag)]
 
-        attributes = element.render_attributes(self.compiler.options.attr_wrapper)
+        attributes = element.render_attributes(self.compiler.options)
         if attributes:
             start.append(' ' + self.replace_inline_variables(attributes))
 

--- a/hamlpy/parser/nodes.py
+++ b/hamlpy/parser/nodes.py
@@ -63,7 +63,7 @@ def read_node(stream, prev, compiler):
 
         # peek ahead to so we don't try to parse an element from a variable node starting #{ or a Django tag ending %}
         if stream.text[stream.ptr] in ELEMENT_PREFIXES and stream.text[stream.ptr:stream.ptr+2] not in ('#{', '%}'):
-            element = read_element(stream, compiler.options)
+            element = read_element(stream, compiler)
             return ElementNode(element, indent, compiler)
 
         # all other nodes are single line

--- a/hamlpy/test/test_attributes.py
+++ b/hamlpy/test/test_attributes.py
@@ -152,6 +152,9 @@ class AttributeDictParserTest(unittest.TestCase):
             "(class=[ 'a', 'b', 'c' ] data-list=[1, 2, 3])"
         )) == {'class': ['a', 'b', 'c'], 'data-list': ['1', '2', '3']}
 
+        # variable attribute values
+        assert dict(self._parse('(foo=bar)')) == {'foo': '{{ bar }}'}
+
         # attribute values can be multi-line Haml
         assert dict(self._parse("""(
                 class=

--- a/hamlpy/test/test_attributes.py
+++ b/hamlpy/test/test_attributes.py
@@ -39,11 +39,11 @@ class AttributeDictParserTest(unittest.TestCase):
         # boolean attributes
         assert dict(self._parse(
             "{disabled, class:'test', data-number : 123,\n foo:\"bar\"}"
-        )) == {'disabled': None, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
+        )) == {'disabled': True, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
 
         assert dict(self._parse(
             "{class:'test', data-number : 123,\n foo:\"bar\",  \t   disabled}"
-        )) == {'disabled': None, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
+        )) == {'disabled': True, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
 
         # attribute name has colon
         assert dict(self._parse("{'xml:lang': 'en'}")) == {'xml:lang': 'en'}
@@ -132,11 +132,11 @@ class AttributeDictParserTest(unittest.TestCase):
         # boolean attributes
         assert dict(self._parse(
             "(disabled class='test' data-number = 123\n foo=\"bar\")"
-        )) == {'disabled': None, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
+        )) == {'disabled': True, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
 
         assert dict(self._parse(
             "(class='test' data-number = 123\n foo=\"bar\"  \t   disabled)"
-        )) == {'disabled': None, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
+        )) == {'disabled': True, 'class': 'test', 'data-number': '123', 'foo': 'bar'}
 
         # attribute name has colon
         assert dict(self._parse('(xml:lang="en")')) == {'xml:lang': 'en'}

--- a/hamlpy/test/test_attributes.py
+++ b/hamlpy/test/test_attributes.py
@@ -4,7 +4,7 @@ import unittest
 
 from collections import OrderedDict
 
-from hamlpy.compiler import Options
+from hamlpy.compiler import Compiler
 from hamlpy.parser.attributes import read_attribute_dict
 from hamlpy.parser.core import Stream, ParseException
 
@@ -13,12 +13,12 @@ class AttributeDictParserTest(unittest.TestCase):
 
     @staticmethod
     def _parse(text):
-        return read_attribute_dict(Stream(text), Options())
+        return read_attribute_dict(Stream(text), Compiler())
 
     def test_read_ruby_style_attribute_dict(self):
         # empty dict
         stream = Stream("{}><")
-        assert dict(read_attribute_dict(stream, Options())) == {}
+        assert dict(read_attribute_dict(stream, Compiler())) == {}
         assert stream.text[stream.ptr:] == '><'
 
         # string values

--- a/hamlpy/test/test_compiler.py
+++ b/hamlpy/test/test_compiler.py
@@ -47,6 +47,9 @@ class CompilerTest(unittest.TestCase):
         # HTML style
         self._test('%form(foo=bar id="myform")', "<form foo='{{ bar }}' id='myform'></form>")
 
+        # multiple dicts
+        self._test('%a(a="b"){:c => "d"} Stuff', "<a a='b' c='d'>Stuff</a>")
+
     def test_boolean_attributes(self):
         self._test("%input{required}", "<input required>")
         self._test("%input{required, a: 'b'}", "<input required a='b'>")

--- a/hamlpy/test/test_compiler.py
+++ b/hamlpy/test/test_compiler.py
@@ -44,6 +44,9 @@ class CompilerTest(unittest.TestCase):
         # attribute whitespace is ignored
         self._test('%form{ id : "myform" }', "<form id='myform'></form>")
 
+        # HTML style
+        self._test('%form(foo=bar id="myform")', "<form foo='{{ bar }}' id='myform'></form>")
+
     def test_boolean_attributes(self):
         self._test("%input{required}", "<input required>")
         self._test("%input{required, a: 'b'}", "<input required a='b'>")

--- a/hamlpy/test/test_compiler.py
+++ b/hamlpy/test/test_compiler.py
@@ -56,6 +56,7 @@ class CompilerTest(unittest.TestCase):
         self._test("%input{a: 'b', required, b: 'c'}", "<input a='b' required b='c'>")
         self._test("%input{a: 'b', required}", "<input a='b' required>")
         self._test("%input{checked, required, visible}", "<input checked required visible>")
+        self._test("%input(checked=true)", "<input checked>")
 
     def test_attribute_values_as_tuples_and_lists(self):
         # id attribute as tuple

--- a/hamlpy/test/test_compiler.py
+++ b/hamlpy/test/test_compiler.py
@@ -50,6 +50,8 @@ class CompilerTest(unittest.TestCase):
         # multiple dicts
         self._test('%a(a="b"){:c => "d"} Stuff', "<a a='b' c='d'>Stuff</a>")
 
+        self._test_error('%a(b=)', "Unexpected \")\". @ \"%a(b=)\" <-")
+
     def test_boolean_attributes(self):
         self._test("%input{required}", "<input required>")
         self._test("%input{required, a: 'b'}", "<input required a='b'>")
@@ -57,6 +59,7 @@ class CompilerTest(unittest.TestCase):
         self._test("%input{a: 'b', required}", "<input a='b' required>")
         self._test("%input{checked, required, visible}", "<input checked required visible>")
         self._test("%input(checked=true)", "<input checked>")
+        self._test("%input(checked=true)", "<input checked='checked' />", compiler_options={'format': 'xhtml'})
 
     def test_attribute_values_as_tuples_and_lists(self):
         # id attribute as tuple

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -35,7 +35,7 @@ class ElementTest(unittest.TestCase):
         self.assertEqual(element.tag, 'input')
         self.assertEqual(element.id, None)
         self.assertEqual(element.classes, [])
-        self.assertEqual(dict(element.attributes), {'required': None})
+        self.assertEqual(dict(element.attributes), {'required': True})
         self.assertEqual(element.nuke_outer_whitespace, False)
         self.assertEqual(element.nuke_inner_whitespace, False)
         self.assertEqual(element.self_close, True)  # input is implicitly self-closing

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -4,7 +4,7 @@ import unittest
 
 from collections import OrderedDict
 
-from hamlpy.compiler import Options
+from hamlpy.compiler import Compiler
 from hamlpy.parser.core import Stream
 from hamlpy.parser.elements import Element, read_tag, read_element
 
@@ -18,7 +18,7 @@ class ElementTest(unittest.TestCase):
 
     def test_read_element(self):
         stream = Stream('%angular:ng-repeat.my-class#my-id(class="test")></=  Hello  \n.next-element')
-        element = read_element(stream, Options())
+        element = read_element(stream, Compiler())
         self.assertEqual(element.tag, 'angular:ng-repeat')
         self.assertEqual(element.id, 'my-id')
         self.assertEqual(element.classes, ['test', 'my-class'])
@@ -31,7 +31,7 @@ class ElementTest(unittest.TestCase):
         self.assertEqual(stream.text[stream.ptr:], '.next-element')
 
         stream = Stream('%input{required}  ')
-        element = read_element(stream, Options())
+        element = read_element(stream, Compiler())
         self.assertEqual(element.tag, 'input')
         self.assertEqual(element.id, None)
         self.assertEqual(element.classes, [])
@@ -152,4 +152,4 @@ class ElementTest(unittest.TestCase):
 
     @staticmethod
     def _read_element(text):
-        return read_element(Stream(text), Options())
+        return read_element(Stream(text), Compiler())


### PR DESCRIPTION
* Interpret an unquoted HTML style attribute value as a variable, e.g. `.(foo=bar)` is compiled to `<div foo="{{ bar }}"></div>`
* Support multiple attribute dictionaries on a single element. The example given in the Haml reference is `%a(title=@title){:href => @link.href} Stuff`
* Ensure attribute values which are themselves Haml are parsed with same options as rest of document
* Interpret `.(foo=True)` as a boolean attribute, and `.(foo=None)` as removing attribute `foo`
* Render boolean attributes as `checked="checked"` in XHTML mode