### PR TITLE
Newline Fix

### DIFF
--- a/hamlpy/parser/nodes.py
+++ b/hamlpy/parser/nodes.py
@@ -47,7 +47,17 @@ def read_node(stream, prev, compiler):
         # convert indent to be all of the first character
         if indent:
             indent = indent[0] * len(indent)
-
+        
+        # return carriages are recorded as newlines on previous node
+        # if followed by a newline, it is skipped
+        if stream.text[stream.ptr] == '\r':
+            if prev:
+                prev.newlines += 1
+            stream.ptr += 1
+            if stream.text[stream.ptr] == '\n':
+                stream.ptr += 1
+            continue
+            
         # empty lines are recorded as newlines on previous node
         if stream.text[stream.ptr] == '\n':
             if prev:

--- a/hamlpy/parser/nodes.py
+++ b/hamlpy/parser/nodes.py
@@ -48,7 +48,7 @@ def read_node(stream, prev, compiler):
         if indent:
             indent = indent[0] * len(indent)
         
-        # return carriages are recorded as newlines on previous node
+        # carriage returns are recorded as newlines on previous node
         # if followed by a newline, it is skipped
         if stream.text[stream.ptr] == '\r':
             if prev:

--- a/hamlpy/parser/nodes.py
+++ b/hamlpy/parser/nodes.py
@@ -48,7 +48,7 @@ def read_node(stream, prev, compiler):
         if indent:
             indent = indent[0] * len(indent)
         
-        # carriage returns are recorded as newlines on previous node
+        # empty lines with carriage returns are recorded as newlines on previous node
         # if followed by a newline, it is skipped
         if stream.text[stream.ptr] == '\r':
             if prev:


### PR DESCRIPTION
The parser was only looking for the line feed character ('\n'), so when it encountered an empty line with a Windows-style newline beginning with a carriage return ('\r\n'), it would miss it and instead return a PlaintextNode. This would mess up the structure of the generated HTML if the indentation prior to the newline characters was incorrect. For example, a blank line with no indentation would collapse all previous elements and put the following content after the html closing tag.