### PR TITLE
Added support for markdown extensions. Fixes #77

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -538,6 +538,12 @@ Surrounds the filtered text with &lt;style type="text/stylus"&gt; and CDATA tags
 
 Converts the filter text from Markdown to HTML, using the Python [Markdown library](http://freewisdom.org/projects/python-markdown/).
 
+You can also specify the enabled extensions using the setting HAMLPY_MARKDOWN_EXTENSIONS and assigning a list of valid extensions to it. See [Markdown library extensions documentation](https://python-markdown.github.io/extensions/) for available extensions. For example:
+
+```python
+HAMLPY_MARKDOWN_EXTENSIONS = ['extras']
+```
+
 ### :highlight
 
 This will output the filtered text with syntax highlighting using [Pygments](http://pygments.org).

--- a/hamlpy/parser/filters.py
+++ b/hamlpy/parser/filters.py
@@ -11,6 +11,8 @@ content into suitable <style> and <script> that can be transformed later by some
 import sys
 from io import StringIO
 
+from django.conf import settings
+
 # Pygments and Markdown are optional dependencies which may or may not be available
 try:
     import pygments
@@ -85,7 +87,8 @@ def markdown(content, options):
     if not _markdown_available:
         raise ParseException("Markdown is not available")
 
-    return markdown_lib(content)
+    md_extensions = getattr(settings, 'HAMLPY_MARKDOWN_EXTENSIONS', [])
+    return markdown_lib(content, extensions=md_extensions)
 
 
 def highlight(content, options):


### PR DESCRIPTION
Added an option in Django settings called HAMLPY_MARKDOWN_EXTENSIONS that allow the user to specify the optional extensions to use when rendering markdown text using markdown library.