### PR TITLE
Allow class names to include colons

### DIFF
--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -4,18 +4,21 @@ from .attributes import read_attribute_dict
 from .core import read_line, read_word
 
 # non-word characters that we allow in tag names, ids and classes
-DOM_OBJECT_EXTRA_CHARS = ("-",)
+TAG_EXTRA_CHARS = ("-",)
+
+# non-word characters that we allow in ids and classes
+ID_OR_CLASS_EXTRA_CHARS = ("-", ":")
 
 
 def read_tag(stream):
     """
     Reads an element tag, e.g. span, ng-repeat, cs:dropdown
     """
-    part1 = read_word(stream, DOM_OBJECT_EXTRA_CHARS)
+    part1 = read_word(stream, TAG_EXTRA_CHARS)
 
     if stream.ptr < stream.length and stream.text[stream.ptr] == ":":
         stream.ptr += 1
-        part2 = read_word(stream, DOM_OBJECT_EXTRA_CHARS)
+        part2 = read_word(stream, TAG_EXTRA_CHARS)
     else:
         part2 = None
 
@@ -39,7 +42,7 @@ def read_element(stream, compiler):
         # Element may start with a period representing an unidentified div rather than a CSS class. In this case it
         # can't have other classes or ids, e.g. .{foo:"bar"}
         next_ch = stream.text[stream.ptr + 1] if stream.ptr < stream.length - 1 else None
-        if not (next_ch.isalnum() or next_ch == "_" or next_ch in DOM_OBJECT_EXTRA_CHARS):
+        if not (next_ch.isalnum() or next_ch == "_" or next_ch in ID_OR_CLASS_EXTRA_CHARS):
             stream.ptr += 1
             empty_class = True
 
@@ -51,7 +54,7 @@ def read_element(stream, compiler):
             is_id = stream.text[stream.ptr] == "#"
             stream.ptr += 1
 
-            id_or_class = read_word(stream, DOM_OBJECT_EXTRA_CHARS)
+            id_or_class = read_word(stream, ID_OR_CLASS_EXTRA_CHARS)
             if is_id:
                 _id = id_or_class
             else:

--- a/hamlpy/test/templates/classIdMixtures.hamlpy
+++ b/hamlpy/test/templates/classIdMixtures.hamlpy
@@ -1,4 +1,4 @@
-%div#Article.article.entry{'id':'123', class:'true'}
+%div#Article.article.entry.hover:no-underline{'id':'123', class:'true'}
   Now this is interesting
-%div.article.entry#Article(id='123' class='true')
+%div.article.entry.hover:no-underline#Article(id='123' class='true')
   Now this is really interesting

--- a/hamlpy/test/templates/classIdMixtures.html
+++ b/hamlpy/test/templates/classIdMixtures.html
@@ -1,6 +1,6 @@
-<div class='true article entry' id='Article_123'>
+<div class='true article entry hover:no-underline' id='Article_123'>
   Now this is interesting
 </div>
-<div class='true article entry' id='Article_123'>
+<div class='true article entry hover:no-underline' id='Article_123'>
   Now this is really interesting
 </div>

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -13,11 +13,11 @@ class ElementTest(unittest.TestCase):
         self.assertEqual(stream.text[stream.ptr :], "(")
 
     def test_read_element(self):
-        stream = Stream('%angular:ng-repeat.my-class#my-id(class="test")></=  Hello  \n.next-element')
+        stream = Stream('%angular:ng-repeat.my-class.other:class#my-id(class="test")></=  Hello  \n.next-element')
         element = read_element(stream, Compiler())
         self.assertEqual(element.tag, "angular:ng-repeat")
         self.assertEqual(element.id, "my-id")
-        self.assertEqual(element.classes, ["test", "my-class"])
+        self.assertEqual(element.classes, ["test", "my-class", "other:class"])
         self.assertEqual(dict(element.attributes), {"class": "test"})
         self.assertEqual(element.nuke_outer_whitespace, True)
         self.assertEqual(element.nuke_inner_whitespace, True)
@@ -79,9 +79,9 @@ class ElementTest(unittest.TestCase):
         element = self._read_element("%div.someClass.anotherClass#someId")
         assert element.classes == ["someClass", "anotherClass"]
 
-        # classes can contain hypens and underscores
-        element = self._read_element("%div.-some-class-._another_class_")
-        assert element.classes == ["-some-class-", "_another_class_"]
+        # classes can contain hypens, underscores and colons
+        element = self._read_element("%div.-some-class-._another_class_.also:class")
+        assert element.classes == ["-some-class-", "_another_class_", "also:class"]
 
         # no class
         element = self._read_element("%div#someId")


### PR DESCRIPTION
Tailwind uses these for responsive classes