### PR TITLE
Fix using double quotes as attribute wrapper

### DIFF
--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -123,6 +123,7 @@ class Element(object):
     )
 
     DEFAULT_TAG = "div"
+    ESCAPED = {'"': "&quot;", "'": "&#39;"}
 
     def __init__(
         self,
@@ -190,10 +191,10 @@ class Element(object):
 
         return " ".join(rendered)
 
-    @staticmethod
-    def _escape_attribute_quotes(v, attr_wrapper):
+    @classmethod
+    def _escape_attribute_quotes(cls, v, attr_wrapper):
         """
-        Escapes quotes with a backslash, except those inside a Django tag
+        Escapes quotes, except those inside a Django tag
         """
         escaped = []
         inside_tag = False
@@ -204,8 +205,8 @@ class Element(object):
                 inside_tag = False
 
             if v[i] == attr_wrapper and not inside_tag:
-                escaped.append("\\")
-
-            escaped.append(v[i])
+                escaped.append(cls.ESCAPED[attr_wrapper])
+            else:
+                escaped.append(v[i])
 
         return "".join(escaped)

--- a/hamlpy/test/test_elements.py
+++ b/hamlpy/test/test_elements.py
@@ -43,8 +43,13 @@ class ElementTest(unittest.TestCase):
         s1 = Element._escape_attribute_quotes("""{% url 'blah' %}""", attr_wrapper="'")
         assert s1 == """{% url 'blah' %}"""
 
-        s2 = Element._escape_attribute_quotes("""blah's blah''s {% url 'blah' %} blah's blah''s""", attr_wrapper="'")
-        assert s2 == r"blah\'s blah\'\'s {% url 'blah' %} blah\'s blah\'\'s"
+        s2 = Element._escape_attribute_quotes(
+            """'foo'="bar" {% url 'blah' "blah" %} blah's blah''s""", attr_wrapper="'"
+        )
+        assert s2 == """&#39;foo&#39;="bar" {% url 'blah' "blah" %} blah&#39;s blah&#39;&#39;s"""
+
+        s3 = Element._escape_attribute_quotes("""'foo'="bar" {% url 'blah' "blah" %}""", attr_wrapper='"')
+        assert s3 == """'foo'=&quot;bar&quot; {% url 'blah' "blah" %}"""
 
     def test_parses_tag(self):
         element = self._read_element("%span.class")


### PR DESCRIPTION
Currently `a(href="don't")` becomes `<a href='don\'t'>` which isn't valid and should be `<a href='don&#39;t'>`.

If using double quotes for attributes then `a(onclick='alert("foo")')` currently becomes `<a onclick="alert(\"foo\")">` which again isn't valid and should be `<a onclick="alert(&quot;foo&quot;)">`