### PR TITLE
Add smart_quotes option to replace conflicting quotes in attributes

### DIFF
--- a/hamlpy/compiler.py
+++ b/hamlpy/compiler.py
@@ -25,6 +25,7 @@ class Options(object):
         self.tag_config = "django"  # Django vs Jinja2 tags
         self.custom_self_closing_tags = {}  # additional self-closing tags
         self.endblock_names = False  # include block name on endblock closing tags
+        self.smart_quotes = False
         self.debug_tree = False
 
         for k, v in kwargs.items():

--- a/hamlpy/parser/elements.py
+++ b/hamlpy/parser/elements.py
@@ -180,7 +180,7 @@ class Element(object):
                 else:
                     rendered.append(name)
             else:
-                value = self._escape_attribute_quotes(value, options.attr_wrapper)
+                value = self._escape_attribute_quotes(value, options.attr_wrapper, options.smart_quotes)
                 rendered.append("%s=%s" % (name, attr_wrap(value)))
 
         if len(self.classes) > 0:
@@ -192,7 +192,7 @@ class Element(object):
         return " ".join(rendered)
 
     @classmethod
-    def _escape_attribute_quotes(cls, v, attr_wrapper):
+    def _escape_attribute_quotes(cls, v, attr_wrapper, smart_quotes=False):
         """
         Escapes quotes, except those inside a Django tag
         """
@@ -205,7 +205,12 @@ class Element(object):
                 inside_tag = False
 
             if v[i] == attr_wrapper and not inside_tag:
-                escaped.append(cls.ESCAPED[attr_wrapper])
+                if smart_quotes and attr_wrapper in ('"', "'"):
+                    repl = '"' if v[i] == "'" else "'"
+                else:
+                    repl = cls.ESCAPED[attr_wrapper]
+
+                escaped.append(repl)
             else:
                 escaped.append(v[i])
 

--- a/hamlpy/test/test_compiler.py
+++ b/hamlpy/test/test_compiler.py
@@ -337,6 +337,29 @@ test""",
             options={"attr_wrapper": '"', "format": "xhtml", "escape_attrs": True},
         )
 
+        # smart quotes...
+
+        self._test(
+            """%a(onclick="alert('hi')")""",
+            """<a onclick="alert('hi')"></a>""",
+            options={"attr_wrapper": '"', "smart_quotes": False},
+        )
+        self._test(
+            """%a(onclick="alert('hi')")""",
+            """<a onclick="alert('hi')"></a>""",
+            options={"attr_wrapper": '"', "smart_quotes": True},
+        )
+        self._test(
+            """%a(onclick="alert('hi')")""",
+            """<a onclick='alert("hi")'></a>""",
+            options={"attr_wrapper": "'", "smart_quotes": True},
+        )
+        self._test(
+            """%a(onclick='alert("hi {% trans "world" %}")')""",
+            """<a onclick="alert('hi {% trans "world" %}')"></a>""",
+            options={"attr_wrapper": '"', "smart_quotes": True},
+        )
+
     def test_attr_escaping(self):
         self._test(
             """#foo{:class => '<?php echo "&quot;" ?>'}""",


### PR DESCRIPTION
Automatically compile...

```
%a(onclick='alert("hi")')
```

to

```
<a onclick="alert('hi')"></a>
```